### PR TITLE
example using an Em.run.later in a test

### DIFF
--- a/app/components/delayed-action-button.js
+++ b/app/components/delayed-action-button.js
@@ -5,7 +5,9 @@ export default Em.Component.extend({
   buttonText: 'Click me',
   buttonPressed: task(function * () {
     this.set('buttonText', '...please wait...');
-    yield timeout(1000);
+    yield timeout(1001);
+    this.set('buttonText', '...continue to wait...');
+    yield timeout(1002);
     this.set('buttonText', 'Click me again');
   }).drop()
 });

--- a/app/components/delayed-action-button.js
+++ b/app/components/delayed-action-button.js
@@ -1,0 +1,11 @@
+import Em from 'ember';
+import { task, timeout } from 'ember-concurrency';
+
+export default Em.Component.extend({
+  buttonText: 'Click me',
+  buttonPressed: task(function * () {
+    this.set('buttonText', '...please wait...');
+    yield timeout(1000);
+    this.set('buttonText', 'Click me again');
+  }).drop()
+});

--- a/app/serializers/app-integration.js
+++ b/app/serializers/app-integration.js
@@ -1,3 +1,4 @@
+import Em from 'ember';
 import DS from 'ember-data';
 
 export default DS.JSONSerializer.extend({

--- a/app/templates/components/delayed-action-button.hbs
+++ b/app/templates/components/delayed-action-button.hbs
@@ -1,0 +1,1 @@
+<button onclick={{perform buttonPressed}}>{{buttonText}}</button>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,1 +1,4 @@
 hello
+
+
+{{delayed-action-button}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
-    // Add options here
+    babel: {
+      includePolyfill: true,
+    }
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-sass": "5.3.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-concurrency": "0.6.1",
     "ember-data": "^2.4.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",

--- a/tests/integration/components/delayed-action-button-test.js
+++ b/tests/integration/components/delayed-action-button-test.js
@@ -1,0 +1,28 @@
+import Em from 'ember';
+import { test, moduleForComponent } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('delayed-action-button', 'Integration | Component | delayed action button', {
+  integration: true
+});
+
+test('should change text after a delay', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{delayed-action-button}}`);
+
+  assert.equal(this.$('button').text(), 'Click me');
+
+  Em.run(() => {
+    this.$('button').click();
+  });
+
+  assert.equal(this.$('button').text(), '...please wait...');
+
+  Em.run.later(() => {
+    assert.equal(this.$('button').text(), 'Click me again');
+  }, 1050);
+
+  return wait();
+});

--- a/tests/integration/components/delayed-action-button-test.js
+++ b/tests/integration/components/delayed-action-button-test.js
@@ -3,12 +3,12 @@ import { test, moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 function mockRunLater(context) {
-  context.mockRunLater = { //TODO: GJ: naming
-    originalRunLater: Em.run.later,
-    defferedRunLaters: [],
+  context.mockedRunLater = {
+    original: Em.run.later,
+    deffereds: [],
     next: function() {
       Em.run(() => {
-        let defered = context.mockRunLater.defferedRunLaters.splice(0, 1)[0];
+        let defered = context.mockedRunLater.deffereds.splice(0, 1)[0];
 
         if(defered) {
           defered.resolve();
@@ -22,12 +22,12 @@ function mockRunLater(context) {
   Em.run.later = function(fn) {
     let defer = Em.RSVP.defer();
     defer.promise.then(fn);
-    context.mockRunLater.defferedRunLaters.push(defer);
+    context.mockedRunLater.deffereds.push(defer);
   };
 }
 
 function restoreRunLater(context) {
-  Em.run.later = context.mockRunLater.originalRunLater;
+  Em.run.later = context.mockedRunLater.original;
 }
 
 moduleForComponent('delayed-action-button', 'Integration | Component | delayed action button', {
@@ -48,11 +48,11 @@ test('option 2: should change text after a delay', function(assert) {
 
   assert.equal(this.$('button').text(), '...please wait...');
 
-  this.mockRunLater.next();
+  this.mockedRunLater.next();
 
   assert.equal(this.$('button').text(), '...continue to wait...');
 
-  this.mockRunLater.next();
+  this.mockedRunLater.next();
 
   assert.equal(this.$('button').text(), 'Click me again');
 

--- a/tests/integration/components/delayed-action-button-test.js
+++ b/tests/integration/components/delayed-action-button-test.js
@@ -1,55 +1,84 @@
 import Em from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
-import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
+
+function mockRunLater(context) {
+  context.mockRunLater = { //TODO: GJ: naming
+    originalRunLater: Em.run.later,
+    defferedRunLaters: [],
+    next: function() {
+      Em.run(() => {
+        let defered = context.mockRunLater.defferedRunLaters.splice(0, 1)[0];
+
+        if(defered) {
+          defered.resolve();
+        } else {
+          throw "there are no more defered run laters";
+        }
+      });
+    }
+  };
+
+  Em.run.later = function(fn) {
+    let defer = Em.RSVP.defer();
+    defer.promise.then(fn);
+    context.mockRunLater.defferedRunLaters.push(defer);
+  };
+}
+
+function restoreRunLater(context) {
+  Em.run.later = context.mockRunLater.originalRunLater;
+}
 
 moduleForComponent('delayed-action-button', 'Integration | Component | delayed action button', {
   integration: true
 });
 
-//this test uses a longer `Em.run.later`
-test('option 1: should change text after a delay', function(assert) {
-  assert.expect(3);
-
-  this.render(hbs`{{delayed-action-button}}`);
-
-  assert.equal(this.$('button').text(), 'Click me');
-
-  Em.run(() => this.$('button').click());
-
-  assert.equal(this.$('button').text(), '...please wait...');
-
-  Em.run.later(() => {
-    assert.equal(this.$('button').text(), 'Click me again');
-  }, 1050);
-
-  return wait();
-});
-
 //this test mocks `Em.run.later`
 test('option 2: should change text after a delay', function(assert) {
-  assert.expect(3);
+  mockRunLater(this);
+
+  assert.expect(4);
 
   this.render(hbs`{{delayed-action-button}}`);
 
   assert.equal(this.$('button').text(), 'Click me');
 
-  let originalRunLater = Em.run.later;
-  let laterDefer;
-  Em.run.later = function(fn) {
-    laterDefer = Em.RSVP.defer();
-    laterDefer.promise.then(fn);
-  };
-
   Em.run(() => this.$('button').click());
 
   assert.equal(this.$('button').text(), '...please wait...');
 
-  Em.run(() => laterDefer.resolve());
+  this.mockRunLater.next();
+
+  assert.equal(this.$('button').text(), '...continue to wait...');
+
+  this.mockRunLater.next();
 
   assert.equal(this.$('button').text(), 'Click me again');
 
-  Em.run.later = originalRunLater;
-
-  return wait();
+  restoreRunLater(this);
 });
+
+
+//this is brittle and slow, don't use it. It uses a longer `Em.run.later`
+// test('option 1: should change text after a delay', function(assert) {
+//   assert.expect(4);
+//
+//   this.render(hbs`{{delayed-action-button}}`);
+//
+//   assert.equal(this.$('button').text(), 'Click me');
+//
+//   Em.run(() => this.$('button').click());
+//
+//   assert.equal(this.$('button').text(), '...please wait...');
+//
+//   Em.run.later(() => {
+//     assert.equal(this.$('button').text(), '...continue to wait...');
+//   }, 1050);
+//
+//   Em.run.later(() => {
+//     assert.equal(this.$('button').text(), 'Click me again');
+//   }, 2050);
+//
+//   return wait();
+// });

--- a/tests/integration/components/delayed-action-button-test.js
+++ b/tests/integration/components/delayed-action-button-test.js
@@ -7,22 +7,49 @@ moduleForComponent('delayed-action-button', 'Integration | Component | delayed a
   integration: true
 });
 
-test('should change text after a delay', function(assert) {
+//this test uses a longer `Em.run.later`
+test('option 1: should change text after a delay', function(assert) {
   assert.expect(3);
 
   this.render(hbs`{{delayed-action-button}}`);
 
   assert.equal(this.$('button').text(), 'Click me');
 
-  Em.run(() => {
-    this.$('button').click();
-  });
+  Em.run(() => this.$('button').click());
 
   assert.equal(this.$('button').text(), '...please wait...');
 
   Em.run.later(() => {
     assert.equal(this.$('button').text(), 'Click me again');
   }, 1050);
+
+  return wait();
+});
+
+//this test mocks `Em.run.later`
+test('option 2: should change text after a delay', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{delayed-action-button}}`);
+
+  assert.equal(this.$('button').text(), 'Click me');
+
+  let originalRunLater = Em.run.later;
+  let laterDefer;
+  Em.run.later = function(fn) {
+    laterDefer = Em.RSVP.defer();
+    laterDefer.promise.then(fn);
+  };
+
+  Em.run(() => this.$('button').click());
+
+  assert.equal(this.$('button').text(), '...please wait...');
+
+  Em.run(() => laterDefer.resolve());
+
+  assert.equal(this.$('button').text(), 'Click me again');
+
+  Em.run.later = originalRunLater;
 
   return wait();
 });


### PR DESCRIPTION
/cc @antidis

TODO:
- [x] option 1: use a longer `Em.run.later` in a test
- [x] option 2: mock `Em.run.later`
